### PR TITLE
Move to `tokio` crate, drop handle arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ license = "MIT"
 keywords = ["hyper", "web", "http", "file"]
 
 [dependencies]
-futures = "0.1"
-hyper = "0.11"
-tokio-core = "0.1"
-url = "1.1"
+futures = "0.1.21"
+hyper = "0.11.25"
+tokio = "0.1.5"
+url = "1.7.0"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempdir = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 extern crate futures;
 extern crate hyper;
-extern crate tokio_core;
+extern crate tokio;
 extern crate url;
 
 mod requested_path;


### PR DESCRIPTION
This moves to the new `tokio` crate, which no longer requires passing `Handle` around. We can simply spawn our file reader with `tokio::spawn`. This also simplifies the doc_server example a lot.

For the test suite, I had to add a `Send + 'static` constraint to futures. Hyper and the doc_server example don't need it for some reason, but it appears the futures `Executor` trait requires `Send + 'static` any way?

This'll be a hyper-staticfile 0.2. Depending on how soon it happens in tokio, maybe we should roll futures 0.2 into the hyper-staticfile 0.2 release too.

Fixes #7 