### PR TITLE
Fix for windows issue where directory routes were not correctly resolved to index.html

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.1.21"
 http = "0.1.5"
 hyper = "0.12.1"
 tokio = "0.1.7"
+tokio-fs = "0.1.5"
 url = "1.7.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ extern crate futures;
 extern crate http;
 extern crate hyper;
 extern crate tokio;
+extern crate tokio_fs;
 extern crate url;
 
 mod resolve;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -90,7 +90,7 @@ impl Future for ResolveFuture {
 
                     // If not a directory, serve this file.
                     if !self.is_dir_request {
-                        return Ok(Ready(ResolveResult::Found(file, metadata)));
+                        return Ok(Ready(ResolveResult::Found(file.expect("invalid state"), metadata)));
                     }
 
                     // Resolve the directory index.
@@ -111,7 +111,7 @@ impl Future for ResolveFuture {
                     }
 
                     // Serve this file.
-                    return Ok(Ready(ResolveResult::Found(file, metadata)));
+                    return Ok(Ready(ResolveResult::Found(file.expect("invalid state"), metadata)));
                 },
             }
         }

--- a/src/util/open_with_metadata.rs
+++ b/src/util/open_with_metadata.rs
@@ -39,7 +39,7 @@ impl Future for OpenWithMetadataFuture {
                     OpenWithMetadataState::WaitOpen
                 },
                 OpenWithMetadataState::WaitOpen => {
-                    if self.metadata.clone().unwrap().is_file() {
+                    if self.metadata.clone().expect("Could not read file metadata").is_file() {
                         self.file = Some(try_ready!(File::open(self.path.clone()).poll()));
                     }
                     OpenWithMetadataState::Done


### PR DESCRIPTION
Closes #12 

The issue was around calling `File::open()` on directories. In mac/linux this is fine but errors with a `Permission denied (os error 5)` on Windows.

The fix was to switch the order in which the metadata and file are read in [open_with_metadata.rs]. Now the metadata is read first and if it is a directory it will not attempt to call File::open(). This appears to have fixed the problem and now the example doc server works correctly under windows.