### PR TITLE
Fix handling of directories on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: rust
 rust:
   - stable
   - nightly
+os:
+  - windows
+  - linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ url = "1.7.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.6", features = ["winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ extern crate hyper;
 extern crate tokio;
 extern crate url;
 
+#[cfg(windows)]
+extern crate winapi;
+
 mod resolve;
 mod response_builder;
 mod service;


### PR DESCRIPTION
Fixes #12 and #13

Turns out, we just need to set a magic flag. That flag apparently also bypasses access control in processes with backup privileges, but I think it's safe to assume that's rare for a web server? (Seems like a very bad idea to embed a web server in that kind of process.)

Tests now also run on Windows.

I don't think the winapi dependency is a big deal. We already had an indirect dependency on it.

cc @willemolding