### PR TITLE
Adds automatic detection and setting of Content-Type header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ http = "0.1.5"
 hyper = "0.12.1"
 tokio = "0.1.7"
 url = "1.7.0"
+mime_guess = "1.8.7"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ extern crate chrono;
 extern crate futures;
 extern crate http;
 extern crate hyper;
+extern crate mime_guess;
 extern crate tokio;
 extern crate url;
 

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -1,15 +1,15 @@
-use ::resolve::ResolveResult;
-use ::util::FileResponseBuilder;
 use http::response::Builder as HttpResponseBuilder;
-use http::{Request, Response, Result, StatusCode, header};
+use http::{header, Request, Response, Result, StatusCode};
 use hyper::Body;
+use resolve::ResolveResult;
+use util::FileResponseBuilder;
 
 /// Utility to build the default response for a `resolve` result.
 ///
 /// This struct allows direct access to its fields, but these fields are typically initialized by
 /// the accessors, using the builder pattern. The fields are basically a bunch of settings that
 /// determine the response details.
-#[derive(Clone,Debug,Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ResponseBuilder {
     /// Whether to send cache headers, and what lifespan to indicate.
     pub cache_headers: Option<u32>,
@@ -33,21 +33,15 @@ impl ResponseBuilder {
     /// seldom occurrence.
     pub fn build<B>(&self, req: &Request<B>, result: ResolveResult) -> Result<Response<Body>> {
         match result {
-            ResolveResult::MethodNotMatched => {
-                HttpResponseBuilder::new()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Body::empty())
-            },
-            ResolveResult::UriNotMatched | ResolveResult::NotFound => {
-                HttpResponseBuilder::new()
-                    .status(StatusCode::NOT_FOUND)
-                    .body(Body::empty())
-            },
-            ResolveResult::PermissionDenied => {
-                HttpResponseBuilder::new()
-                    .status(StatusCode::FORBIDDEN)
-                    .body(Body::empty())
-            },
+            ResolveResult::MethodNotMatched => HttpResponseBuilder::new()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::empty()),
+            ResolveResult::UriNotMatched | ResolveResult::NotFound => HttpResponseBuilder::new()
+                .status(StatusCode::NOT_FOUND)
+                .body(Body::empty()),
+            ResolveResult::PermissionDenied => HttpResponseBuilder::new()
+                .status(StatusCode::FORBIDDEN)
+                .body(Body::empty()),
             ResolveResult::IsDirectory => {
                 let mut target = req.uri().path().to_owned();
                 target.push('/');
@@ -60,12 +54,16 @@ impl ResponseBuilder {
                     .status(StatusCode::MOVED_PERMANENTLY)
                     .header(header::LOCATION, target.as_str())
                     .body(Body::empty())
-            },
-            ResolveResult::Found(file, metadata) => {
-                FileResponseBuilder::from_request(req)
-                    .cache_headers(self.cache_headers)
-                    .build(file, metadata)
-            },
+            }
+            ResolveResult::Found(file, metadata, mime) => FileResponseBuilder::from_request(req)
+                .cache_headers(self.cache_headers)
+                .build(file, metadata)
+                .map(|mut r| {
+                    let header_val =
+                        header::HeaderValue::from_str(&mime.to_string()).expect("Invalid mimetype");
+                    r.headers_mut().insert(header::CONTENT_TYPE, header_val);
+                    r
+                }),
         }
     }
 }

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -6,22 +6,24 @@ extern crate hyper_staticfile;
 extern crate tempdir;
 extern crate tokio;
 
-use std::{fs, str};
-use std::io::Write;
 use chrono::{Duration, Utc};
-use futures::{Future, Stream, future};
-use http::{Request, StatusCode, header};
+use futures::{future, Future, Stream};
+use http::{header, Request, StatusCode};
 use hyper_staticfile::{Static, StaticFuture};
+use std::io::Write;
+use std::{fs, str};
 use tempdir::TempDir;
 
-type EmptyFuture = Box<Future<Item=(), Error=()> + Send + 'static>;
+type EmptyFuture = Box<Future<Item = (), Error = ()> + Send + 'static>;
 
 struct Harness {
     static_: Static,
 }
 impl Harness {
     fn run<F>(files: Vec<(&str, &str)>, f: F)
-            where F: FnOnce(Harness) -> EmptyFuture + Send + 'static {
+    where
+        F: FnOnce(Harness) -> EmptyFuture + Send + 'static,
+    {
         let dir = TempDir::new("hyper-staticfile-tests").unwrap();
         for (subpath, contents) in files {
             let fullpath = dir.path().join(subpath);
@@ -34,9 +36,7 @@ impl Harness {
         let mut static_ = Static::new(dir.path().clone());
         static_.cache_headers(Some(3600));
 
-        tokio::run(future::lazy(move || {
-            f(Harness { static_ })
-        }));
+        tokio::run(future::lazy(move || f(Harness { static_ })));
     }
 
     fn request<B>(&mut self, req: Request<B>) -> StaticFuture<B> {
@@ -54,10 +54,10 @@ impl Harness {
 
 #[test]
 fn serves_non_default_file_from_absolute_root_path() {
-    Harness::run(vec![
-        ("file1.html", "this is file1")
-    ], |mut harness| {
-        let f = harness.get("/file1.html").map_err(|e| e.to_string())
+    Harness::run(vec![("file1.html", "this is file1")], |mut harness| {
+        let f = harness
+            .get("/file1.html")
+            .map_err(|e| e.to_string())
             .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
             .and_then(|body| {
                 assert_eq!(str::from_utf8(&body).unwrap(), "this is file1");
@@ -70,10 +70,10 @@ fn serves_non_default_file_from_absolute_root_path() {
 
 #[test]
 fn serves_default_file_from_absolute_root_path() {
-    Harness::run(vec![
-        ("index.html", "this is index")
-    ], |mut harness| {
-        let f = harness.get("/index.html").map_err(|e| e.to_string())
+    Harness::run(vec![("index.html", "this is index")], |mut harness| {
+        let f = harness
+            .get("/index.html")
+            .map_err(|e| e.to_string())
             .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
             .and_then(|body| {
                 assert_eq!(str::from_utf8(&body).unwrap(), "this is index");
@@ -87,8 +87,10 @@ fn serves_default_file_from_absolute_root_path() {
 #[test]
 fn returns_404_if_file_not_found() {
     Harness::run(vec![], |mut harness| {
-        let f = harness.get("/").map_err(|e| e.to_string())
-            .and_then(|res|  {
+        let f = harness
+            .get("/")
+            .map_err(|e| e.to_string())
+            .and_then(|res| {
                 assert_eq!(res.status(), StatusCode::NOT_FOUND);
                 future::ok(())
             })
@@ -99,11 +101,11 @@ fn returns_404_if_file_not_found() {
 
 #[test]
 fn redirects_if_trailing_slash_is_missing() {
-    Harness::run(vec![
-        ("dir/index.html", "this is index"),
-    ], |mut harness| {
-        let f = harness.get("/dir").map_err(|e| e.to_string())
-            .and_then(|res|  {
+    Harness::run(vec![("dir/index.html", "this is index")], |mut harness| {
+        let f = harness
+            .get("/dir")
+            .map_err(|e| e.to_string())
+            .and_then(|res| {
                 assert_eq!(res.status(), StatusCode::MOVED_PERMANENTLY);
 
                 let url = res.headers().get(header::LOCATION).unwrap();
@@ -118,28 +120,29 @@ fn redirects_if_trailing_slash_is_missing() {
 
 #[test]
 fn decodes_percent_notation() {
-    Harness::run(vec![
-        ("has space.html", "file with funky chars")
-    ], |mut harness| {
-        let f = harness.get("/has%20space.html").map_err(|e| e.to_string())
-            .and_then(|res| {
-                res.into_body().concat2().map_err(|e| e.to_string())
-            })
-            .and_then(|body| {
-                assert_eq!(str::from_utf8(&body).unwrap(), "file with funky chars");
-                future::ok(())
-            })
-            .map_err(|err| panic!("{}", err));
-        Box::new(f)
-    });
+    Harness::run(
+        vec![("has space.html", "file with funky chars")],
+        |mut harness| {
+            let f = harness
+                .get("/has%20space.html")
+                .map_err(|e| e.to_string())
+                .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
+                .and_then(|body| {
+                    assert_eq!(str::from_utf8(&body).unwrap(), "file with funky chars");
+                    future::ok(())
+                })
+                .map_err(|err| panic!("{}", err));
+            Box::new(f)
+        },
+    );
 }
 
 #[test]
 fn normalizes_path() {
-    Harness::run(vec![
-        ("index.html", "this is index")
-    ], |mut harness| {
-        let f = harness.get("/xxx/../index.html").map_err(|e| e.to_string())
+    Harness::run(vec![("index.html", "this is index")], |mut harness| {
+        let f = harness
+            .get("/xxx/../index.html")
+            .map_err(|e| e.to_string())
             .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
             .and_then(|body| {
                 assert_eq!(str::from_utf8(&body).unwrap(), "this is index");
@@ -152,10 +155,10 @@ fn normalizes_path() {
 
 #[test]
 fn normalizes_percent_encoded_path() {
-    Harness::run(vec![
-        ("file1.html", "this is file1")
-    ], |mut harness| {
-        let f = harness.get("/xxx/..%2ffile1.html").map_err(|e| e.to_string())
+    Harness::run(vec![("file1.html", "this is file1")], |mut harness| {
+        let f = harness
+            .get("/xxx/..%2ffile1.html")
+            .map_err(|e| e.to_string())
             .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
             .and_then(|body| {
                 assert_eq!(str::from_utf8(&body).unwrap(), "this is file1");
@@ -168,10 +171,10 @@ fn normalizes_percent_encoded_path() {
 
 #[test]
 fn prevents_from_escaping_root() {
-    Harness::run(vec![
-        ("file1.html", "this is file1")
-    ], |mut harness| {
-        let f1 = harness.get("/../file1.html").map_err(|e| e.to_string())
+    Harness::run(vec![("file1.html", "this is file1")], |mut harness| {
+        let f1 = harness
+            .get("/../file1.html")
+            .map_err(|e| e.to_string())
             .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
             .and_then(|body| {
                 assert_eq!(str::from_utf8(&body).unwrap(), "this is file1");
@@ -179,7 +182,9 @@ fn prevents_from_escaping_root() {
             })
             .map_err(|err| panic!("{}", err));
 
-        let f2 = harness.get("/..%2ffile1.html").map_err(|e| e.to_string())
+        let f2 = harness
+            .get("/..%2ffile1.html")
+            .map_err(|e| e.to_string())
             .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
             .and_then(|body| {
                 assert_eq!(str::from_utf8(&body).unwrap(), "this is file1");
@@ -187,7 +192,9 @@ fn prevents_from_escaping_root() {
             })
             .map_err(|err| panic!("{}", err));
 
-        let f3 = harness.get("/xxx/..%2f..%2ffile1.html").map_err(|e| e.to_string())
+        let f3 = harness
+            .get("/xxx/..%2f..%2ffile1.html")
+            .map_err(|e| e.to_string())
             .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
             .and_then(|body| {
                 assert_eq!(str::from_utf8(&body).unwrap(), "this is file1");
@@ -204,16 +211,23 @@ fn prevents_from_escaping_root() {
 
 #[test]
 fn sends_headers() {
-    Harness::run(vec![
-        ("file1.html", "this is file1")
-    ], |mut harness| {
-        let f = harness.get("/file1.html").map_err(|e| e.to_string())
+    Harness::run(vec![("file1.html", "this is file1")], |mut harness| {
+        let f = harness
+            .get("/file1.html")
+            .map_err(|e| e.to_string())
             .and_then(|res| {
                 assert_eq!(res.status(), StatusCode::OK);
                 assert_eq!(res.headers().get(header::CONTENT_LENGTH).unwrap(), "13");
                 assert!(res.headers().get(header::LAST_MODIFIED).is_some());
                 assert!(res.headers().get(header::ETAG).is_some());
-                assert_eq!(res.headers().get(header::CACHE_CONTROL).unwrap(), "public, max-age=3600");
+                assert_eq!(
+                    res.headers().get(header::CACHE_CONTROL).unwrap(),
+                    "public, max-age=3600"
+                );
+                assert_eq!(
+                    res.headers().get(header::CONTENT_TYPE),
+                    Some(&header::HeaderValue::from_static("text/html"))
+                );
                 res.into_body().concat2().map_err(|e| e.to_string())
             })
             .and_then(|body| {
@@ -226,17 +240,35 @@ fn sends_headers() {
 }
 
 #[test]
+fn changes_content_type_on_extension() {
+    Harness::run(vec![("file1.gif", "this is file1")], |mut harness| {
+        let f = harness
+            .get("/file1.gif")
+            .map_err(|e| e.to_string())
+            .and_then(|res| {
+                assert_eq!(
+                    res.headers().get(header::CONTENT_TYPE),
+                    Some(&header::HeaderValue::from_static("image/gif"))
+                );
+                future::ok(())
+            })
+            .map_err(|err| panic!("{}", err));
+        Box::new(f)
+    });
+}
+
+#[test]
 fn serves_file_with_old_if_modified_since() {
-    Harness::run(vec![
-        ("file1.html", "this is file1")
-    ], |mut harness| {
+    Harness::run(vec![("file1.html", "this is file1")], |mut harness| {
         let if_modified = Utc::now() - Duration::seconds(3600);
         let req = Request::builder()
             .uri("/file1.html")
             .header(header::IF_MODIFIED_SINCE, if_modified.to_rfc2822().as_str())
             .body(())
             .expect("unable to build request");
-        let f = harness.request(req).map_err(|e| e.to_string())
+        let f = harness
+            .request(req)
+            .map_err(|e| e.to_string())
             .and_then(|res| res.into_body().concat2().map_err(|e| e.to_string()))
             .and_then(|body| {
                 assert_eq!(str::from_utf8(&body).unwrap(), "this is file1");
@@ -249,16 +281,16 @@ fn serves_file_with_old_if_modified_since() {
 
 #[test]
 fn serves_file_with_new_if_modified_since() {
-    Harness::run(vec![
-        ("file1.html", "this is file1")
-    ], |mut harness| {
+    Harness::run(vec![("file1.html", "this is file1")], |mut harness| {
         let if_modified = Utc::now() + Duration::seconds(3600);
         let req = Request::builder()
             .uri("/file1.html")
             .header(header::IF_MODIFIED_SINCE, if_modified.to_rfc2822().as_str())
             .body(())
             .expect("unable to build request");
-        let f = harness.request(req).map_err(|e| e.to_string())
+        let f = harness
+            .request(req)
+            .map_err(|e| e.to_string())
             .and_then(|res| {
                 assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
                 future::ok(())


### PR DESCRIPTION
Not including the Content-Type header was causing problems in some browsers and browser testing frameworks. This adds mime_guess crate which infers the correct Content-Type based on the file extension. This is added and return in the response. If a type cannot be inferred it will return `application/octet-stream`