### PR TITLE
Upgrade mime_guess to 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ http = "0.1.5"
 hyper = "0.12.1"
 tokio = "0.1.7"
 url = "1.7.0"
-mime_guess = "1.8.7"
+mime_guess = "2.0.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,6 +1,6 @@
 use futures::{Async::*, Future, Poll};
 use http::{Method, Request};
-use mime_guess::Mime;
+use mime_guess::{Mime, MimeGuess};
 use std::convert::AsRef;
 use std::fs::Metadata;
 use std::io::{Error, ErrorKind};
@@ -91,9 +91,9 @@ impl Future for ResolveFuture {
 
                     // If not a directory, serve this file.
                     if !self.is_dir_request {
-                        let mime = mime_guess::guess_mime_type(
-                            self.full_path.as_ref().expect("invalid state"),
-                        );
+                        let mime =
+                            MimeGuess::from_path(self.full_path.as_ref().expect("invalid state"))
+                                .first_or_octet_stream();
                         return Ok(Ready(ResolveResult::Found(file, metadata, mime)));
                     }
 
@@ -115,9 +115,9 @@ impl Future for ResolveFuture {
                     }
 
                     // Serve this file.
-                    let mime = mime_guess::guess_mime_type(
-                        self.full_path.as_ref().expect("invalid state"),
-                    );
+                    let mime =
+                        MimeGuess::from_path(self.full_path.as_ref().expect("invalid state"))
+                            .first_or_octet_stream();
                     return Ok(Ready(ResolveResult::Found(file, metadata, mime)));
                 }
             }


### PR DESCRIPTION
Fixes #19 

I think this can be a patch release (0.4.2). We did a minor bump when we introduced Content-Type, but this at most only changes the mime types we send. (And those aren't stable any way, according to mime_guess docs.)