### PR TITLE
Allow use directly with hyper.

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -63,10 +63,10 @@ impl Static {
     }
 }
 
-impl<B: 'static> Service<Request<B>> for Static {
+impl<B: Send + Sync + 'static> Service<Request<B>> for Static {
     type Response = Response<Body>;
     type Error = IoError;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -1,0 +1,24 @@
+use futures_util::future;
+use hyper::service::{make_service_fn};
+use hyper_staticfile::Static;
+use std::path::Path;
+
+// This test currently only demonstrates that a `Static` instance can be used
+// as a hyper service directly.
+#[tokio::test]
+async fn test_usable_as_hyper_service() {
+    let static_ = Static::new(Path::new("target/doc/"));
+
+    let make_service = make_service_fn(|_| {
+        let static_ = static_.clone();
+        future::ok::<_, hyper::Error>(static_)
+    });
+
+    // Bind to port "0" to allow the OS to pick one that's free, avoiding
+    // the risk of collisions.
+    let addr = ([127, 0, 0, 1], 0).into();
+    let server = hyper::Server::bind(&addr).serve(make_service);
+
+    // It's enough to show that this builds, so no need to execute anything.
+    drop(server);
+}


### PR DESCRIPTION
Hi,

I was attempting to use an instance of `Static` as the sole service in a Hyper server, and found that because the future type wasn't explicitly labeled as `Send`, this wasn't possible:


<details>
<summary>Compiler output</summary>
```
error[E0277]: `(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)` cannot be sent between threads safely
  --> tests/canary.rs:97:14
   |
97 |             .serve(make_service)
   |              ^^^^^ `(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)` cannot be sent between threads safely
   |
   = help: the trait `std::marker::Send` is not implemented for `(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)`
   = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)>`
   = note: required because it appears within the type `std::boxed::Box<(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)>`
   = note: required because it appears within the type `std::pin::Pin<std::boxed::Box<(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)>>`
   = note: required because it appears within the type `hyper::proto::h2::server::H2StreamState<std::pin::Pin<std::boxed::Box<(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)>>, hyper::Body>`
   = note: required because it appears within the type `hyper::proto::h2::server::H2Stream<std::pin::Pin<std::boxed::Box<(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)>>, hyper::Body>`
   = note: required because of the requirements on the impl of `hyper::common::exec::H2Exec<std::pin::Pin<std::boxed::Box<(dyn futures::Future<Output = std::result::Result<hyper::Response<hyper::Body>, std::io::Error>> + 'static)>>, hyper::Body>` for `hyper::common::exec::Exec`
```
</details>

So this small patch adds Send + Sync where appropriate. This also seemed to require making the request body type `B` Sync, seemingly as it's required for `Send` in `http::request::Request`.

The test just shows that this builds correctly–we have plenty of examples that show the underlying service behaviour works, and the Serviced implementation seems like a fairly thin wrapper, so this should be safe.