### PR TITLE
Use spawn_blocking directly to read from files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ categories = ["web-programming::http-server"]
 edition = "2018"
 
 [dependencies]
+bytes = "0.5.3"
 chrono = "0.4.10"
 futures-util = "0.3.1"
 http = "0.2.0"
 hyper = "0.13.0"
 mime_guess = "2.0.1"
 percent-encoding = "2.1.0"
-tokio = { version = "0.2.4", features = ["fs", "macros"] }
+tokio = { version = "0.2.4", features = ["macros"] }
 url = "2.1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,13 +71,13 @@
 //! behavior using `ResponseBuilder` if necessary.
 //!
 //! The `ResponseBuilder` in turn uses `FileResponseBuilder` to serve files that are found. The
-//! `FileResponseBuilder` can also be used directly if you have an existing open `tokio::fs::File`
+//! `FileResponseBuilder` can also be used directly if you have an existing open `std::fs::File`
 //! and want to serve it. It takes care of basic headers, 'not modified' responses, and streaming
 //! the file in the body.
 //!
 //! Finally, there's `FileBytesStream`, which is used by `FileResponseBuilder` to stream the file.
-//! This is a struct wrapping a `tokio::fs::File` and implementing a `futures::Stream` that
-//! produces `Bytes`s. It can be used for streaming a file in custom response.
+//! This is a struct wrapping a `std::fs::File` and implementing a `futures::Stream` that produces
+//! `Bytes`s. It can be used for streaming a file in custom response.
 
 mod resolve;
 mod response_builder;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,10 +1,9 @@
 use crate::util::{open_with_metadata, RequestedPath};
 use http::{Method, Request};
 use mime_guess::{Mime, MimeGuess};
-use std::fs::Metadata;
+use std::fs::{File, Metadata};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::path::PathBuf;
-use tokio::fs::File;
 
 /// The result of `resolve`.
 ///

--- a/src/util/file_bytes_stream.rs
+++ b/src/util/file_bytes_stream.rs
@@ -1,40 +1,89 @@
+use bytes::{BufMut, BytesMut};
 use futures_util::stream::Stream;
 use hyper::body::{Body, Bytes};
-use std::io::Error as IoError;
+use std::fs::File;
+use std::future::Future;
+use std::io::{self, Read};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio::fs::File;
-use tokio::prelude::AsyncRead;
+use tokio::task::{spawn_blocking, JoinHandle};
 
 const BUF_SIZE: usize = 8 * 1024;
 
-/// Wraps a `tokio::fs::File`, and implements a stream of `Bytes`s.
+/// Wraps a `std::fs::File`, and implements an async stream of `Bytes`s.
 pub struct FileBytesStream {
-    file: File,
-    buf: Box<[u8; BUF_SIZE]>,
+    file: Arc<File>,
+    state: State,
+}
+
+enum State {
+    Invalid,
+    Idle(BytesMut),
+    Busy(JoinHandle<(io::Result<usize>, BytesMut)>),
 }
 
 impl FileBytesStream {
     /// Create a new stream from the given file.
     pub fn new(file: File) -> FileBytesStream {
-        let buf = Box::new([0; BUF_SIZE]);
-        FileBytesStream { file, buf }
+        let file = Arc::new(file);
+        let state = State::Idle(BytesMut::new());
+        FileBytesStream { file, state }
     }
 }
 
 impl Stream for FileBytesStream {
-    type Item = Result<Bytes, IoError>;
+    type Item = Result<Bytes, io::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        let Self {
-            ref mut file,
-            ref mut buf,
-        } = *self;
-        match Pin::new(file).poll_read(cx, &mut buf[..]) {
-            Poll::Ready(Ok(0)) => Poll::Ready(None),
-            Poll::Ready(Ok(size)) => Poll::Ready(Some(Ok(self.buf[..size].to_owned().into()))),
-            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
-            Poll::Pending => Poll::Pending,
+        loop {
+            let mut state = State::Invalid;
+            std::mem::swap(&mut state, &mut self.state);
+            match state {
+                State::Invalid => {
+                    unreachable!();
+                }
+                State::Idle(mut buf) => {
+                    let file = self.file.clone();
+                    buf.reserve(BUF_SIZE);
+                    self.state = State::Busy(spawn_blocking(move || {
+                        let slice = buf.bytes_mut();
+                        let slice = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                slice.as_mut_ptr() as *mut u8,
+                                slice.len(),
+                            )
+                        };
+                        let res = (&*file).read(slice);
+                        (res, buf)
+                    }));
+                }
+                State::Busy(mut op) => {
+                    let (res, mut buf) = match Pin::new(&mut op).poll(cx) {
+                        Poll::Ready(res) => res?,
+                        Poll::Pending => {
+                            self.state = State::Busy(op);
+                            return Poll::Pending;
+                        }
+                    };
+                    match res {
+                        Ok(0) => {
+                            self.state = State::Idle(buf);
+                            return Poll::Ready(None);
+                        }
+                        Ok(size) => {
+                            unsafe { buf.advance_mut(size) };
+                            let retval = buf.split().freeze();
+                            self.state = State::Idle(buf);
+                            return Poll::Ready(Some(Ok(retval)));
+                        }
+                        Err(e) => {
+                            self.state = State::Idle(buf);
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/util/file_response_builder.rs
+++ b/src/util/file_response_builder.rs
@@ -3,10 +3,9 @@ use chrono::{offset::Local as LocalTz, DateTime, SubsecRound};
 use http::response::Builder as ResponseBuilder;
 use http::{header, HeaderMap, Method, Request, Response, Result, StatusCode};
 use hyper::Body;
-use std::fs::Metadata;
-use tokio::fs::File;
+use std::fs::{File, Metadata};
 
-/// Utility to build responses for serving a `tokio::fs::File`.
+/// Utility to build responses for serving a `std::fs::File`.
 ///
 /// This struct allows direct access to its fields, but these fields are typically initialized by
 /// the accessors, using the builder pattern. The fields are basically a bunch of settings that


### PR DESCRIPTION
Code is rough, and not sure if this is a good idea. Just playing around with ideas in #24.

This bypasses `tokio::fs` and directly uses `spawn_blocking` inspired by Tokio internals. This allows us to skip Tokio's internal buffering, and read directly into our own `BytesMut`.

It looks like, at least on macOS, the OS will fill whatever size buffer we give it.

Some relative results on my own machine using the example server with: `ab -n 1000 -c 10 http://127.0.0.1:3000/search-index.js` (an 975K file), and tweaking our own `BUF_SIZE`:

```
before,   8 KB buffer |  244.64 req/s |  238639.96 KB/s
before,  16 KB buffer |  419.66 req/s |  409371.92 KB/s
after,    8 KB buffer |  274.51 req/s |  267781.17 KB/s
after,   16 KB buffer |  477.92 req/s |  466201.27 KB/s
after,   32 KB buffer |  774.12 req/s |  755135.07 KB/s
after,   64 KB buffer | 1143.46 req/s | 1115419.94 KB/s
after,  128 KB buffer | 1395.01 req/s | 1360802.62 KB/s
after,  256 KB buffer | 1437.07 req/s | 1401834.38 KB/s
after,  512 KB buffer | 1604.41 req/s | 1565070.82 KB/s
after, 1024 KB buffer | 1726.24 req/s | 1683912.61 KB/s
```

These numbers are really shifty, though. But what I do find interesting is that there's an apparent ~13% increase comparing the two runs with 8 KB buffers.

Besides skipping a copy, the other thing I thought might make a difference is the change in `open_with_metadata`. Through Tokio internals, we previously did separate `spawn_blocking` calls for the open and stat steps there, but I combined these in this PR. To try eliminate this, I split the new code into two manual `spawn_blocking` calls and got these numbers:

```
8 KB buffer |  269.98 req/s |  263361.36 KB/s
```

So that only accounts for maybe ~1.5% of that 13% gain.

cc @lnicola 