### PR TITLE
Use `touch -d @1` for TZ-independent UNIX_EPOCH+1

### DIFF
--- a/tests/static.rs
+++ b/tests/static.rs
@@ -210,7 +210,7 @@ async fn no_headers_for_invalid_mtime() {
     let mut file_path = harness.dir.path().to_path_buf();
     file_path.push("file1.html");
     let status = Command::new("touch")
-        .args(&["-t", "197001010000.01"])
+        .args(&["-d", "@1"])
         .arg(file_path)
         .status()
         .unwrap();


### PR DESCRIPTION
In test `no_headers_for_invalid_mtime`, the date string was apparently
using the local timezone, and with my offset -0700 the mtime ended up
much larger than the intended `UNIX_EPOCH+1`, so the test didn't get the
input it wanted. Using `@1` for the date works as desired.