### PR TITLE
response never longer than content-length

### DIFF
--- a/src/util/file_bytes_stream.rs
+++ b/src/util/file_bytes_stream.rs
@@ -13,13 +13,15 @@ const BUF_SIZE: usize = 8 * 1024;
 pub struct FileBytesStream {
     file: File,
     buf: Box<[MaybeUninit<u8>; BUF_SIZE]>,
+    content_length: Option<usize>,
+    written: usize,
 }
 
 impl FileBytesStream {
     /// Create a new stream from the given file.
-    pub fn new(file: File) -> FileBytesStream {
+    pub fn new(file: File, content_length: Option<usize>) -> FileBytesStream {
         let buf = Box::new([MaybeUninit::uninit(); BUF_SIZE]);
-        FileBytesStream { file, buf }
+        FileBytesStream { file, buf, content_length, written: 0 }
     }
 }
 
@@ -30,14 +32,23 @@ impl Stream for FileBytesStream {
         let Self {
             ref mut file,
             ref mut buf,
+            ref content_length,
+            ref mut written,
         } = *self;
-        let mut read_buf = ReadBuf::uninit(&mut buf[..]);
+        let needed: Option<usize> = content_length.map(|cl| cl - *written);
+        let mut read_buf = match needed {
+            Some(0) => return Poll::Ready(None),
+            Some(n) if n < BUF_SIZE => ReadBuf::uninit(&mut buf[..n]),
+            _ => ReadBuf::uninit(&mut buf[..]),
+        };
+
         match Pin::new(file).poll_read(cx, &mut read_buf) {
             Poll::Ready(Ok(())) => {
                 let filled = read_buf.filled();
                 if filled.is_empty() {
                     Poll::Ready(None)
                 } else {
+                    *written += filled.len();
                     Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
                 }
             }

--- a/src/util/file_response_builder.rs
+++ b/src/util/file_response_builder.rs
@@ -138,7 +138,7 @@ impl FileResponseBuilder {
         res.body(if self.is_head {
             Body::empty()
         } else {
-            FileBytesStream::new(file).into_body()
+            FileBytesStream::new(file, Some(metadata.len() as usize)).into_body()
         })
     }
 }

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -12,7 +12,6 @@ type Response = hyper::Response<hyper::Body>;
 type ResponseResult = Result<Response, IoError>;
 
 struct Harness {
-    #[allow(unused)]
     dir: TempDir,
     static_: Static,
 }
@@ -23,7 +22,7 @@ impl Harness {
             let fullpath = dir.path().join(subpath);
             fs::create_dir_all(fullpath.parent().unwrap())
                 .and_then(|_| fs::File::create(fullpath))
-                .and_then(|mut file| file.write(contents.as_bytes()))
+                .and_then(|mut file| file.write_all(contents.as_bytes()))
                 .expect("failed to write fixtures");
         }
 
@@ -31,6 +30,12 @@ impl Harness {
         static_.cache_headers(Some(3600));
 
         Harness { dir, static_ }
+    }
+
+    fn append(&self, subpath: &str, content: &str) {
+        let path = self.dir.path().join(subpath);
+        let mut f = fs::File::options().append(true).open(path).expect("failed to append to fixture");
+        f.write_all(content.as_bytes()).expect("failed to append to fixture");
     }
 
     fn request<B>(&self, req: Request<B>) -> impl Future<Output = ResponseResult> {
@@ -158,6 +163,16 @@ async fn sends_headers() {
         Some(&header::HeaderValue::from_static("text/html"))
     );
 
+    assert_eq!(read_body(res).await, "this is file1");
+}
+
+#[tokio::test]
+async fn content_length() {
+    let harness = Harness::new(vec![("file1.html", "this is file1")]);
+
+    let res = harness.get("/file1.html").await.unwrap();
+    harness.append("file1.html", "more content");
+    assert_eq!(res.headers().get(header::CONTENT_LENGTH).unwrap(), "13");
     assert_eq!(read_body(res).await, "this is file1");
 }
 


### PR DESCRIPTION
Some clients don't like it when the response body is longer than announced in the content-length. If the file is still being appended to, only send the part of the file that already existed when the request was started.