### PR TITLE
Replace tempdir with tempfire

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ url = "2.1.0"
 [dev-dependencies]
 hyper = { version = "1.0.0-rc.1", features = ["http1", "server"] }
 http-body-util = "0.1.0-rc.1"
-tempdir = "0.3.7"
+tempfile = "3"
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread", "net", "io-util"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -15,7 +15,7 @@ use hyper_staticfile::{
     vfs::{FileAccess, MemoryFs},
     AcceptEncoding, Body, Encoding, Static,
 };
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 type Response = hyper::Response<Body>;
 type ResponseResult = Result<Response, IoError>;
@@ -37,7 +37,7 @@ impl Harness {
     }
 
     fn create_temp_dir(files: Vec<(&str, &str)>) -> TempDir {
-        let dir = TempDir::new("hyper-staticfile-tests").unwrap();
+        let dir = TempDir::new().unwrap();
         for (subpath, contents) in files {
             let fullpath = dir.path().join(subpath);
             fs::create_dir_all(fullpath.parent().unwrap())


### PR DESCRIPTION
deprecation notice of tempdir here: https://crates.io/crates/tempdir 
fixes https://rustsec.org/advisories/RUSTSEC-2023-0018.html by removing that dependency