### PR TITLE
Step up to hyper 1.0.0-rc.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ futures-util = "0.3.1"
 http = "0.2.0"
 httpdate = "1.0.1"
 http-range = "0.1.4"
-hyper = "1.0.0-rc.1"
+hyper = "1.0.0-rc.4"
 mime_guess = "2.0.1"
 percent-encoding = "2.1.0"
 rand = "0.8.4"
@@ -24,8 +24,9 @@ tokio = { version = "1.0.0", features = ["fs"] }
 url = "2.1.0"
 
 [dev-dependencies]
-hyper = { version = "1.0.0-rc.1", features = ["http1", "server"] }
-http-body-util = "0.1.0-rc.1"
+hyper = { version = "1.0.0-rc.4", features = ["http1", "server"] }
+hyper-util = { git = "https://github.com/hyperium/hyper-util.git" }
+http-body-util = "0.1.0-rc.3"
 tempfile = "3"
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread", "net", "io-util"] }
 

--- a/examples/doc_server.rs
+++ b/examples/doc_server.rs
@@ -12,6 +12,7 @@ use http::{header, StatusCode};
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_staticfile::{Body, Static};
+use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
 
 async fn handle_request<B>(req: Request<B>, static_: Static) -> Result<Response<Body>, IoError> {
@@ -46,7 +47,7 @@ async fn main() {
         tokio::spawn(async move {
             if let Err(err) = hyper::server::conn::http1::Builder::new()
                 .serve_connection(
-                    stream,
+                    TokioIo::new(stream),
                     service_fn(move |req| handle_request(req, static_.clone())),
                 )
                 .await

--- a/src/service.rs
+++ b/src/service.rs
@@ -100,7 +100,7 @@ where
     type Error = IoError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
-    fn call(&mut self, request: Request<B>) -> Self::Future {
+    fn call(&self, request: Request<B>) -> Self::Future {
         Box::pin(self.clone().serve(request))
     }
 }

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 
 use hyper_staticfile::Static;
 
+use hyper_util::rt::TokioIo;
+
 // This test currently only demonstrates that a `Static` instance can be used
 // as a hyper service directly.
 #[tokio::test]
@@ -9,7 +11,8 @@ async fn test_usable_as_hyper_service() {
     let static_ = Static::new(Path::new("target/doc/"));
 
     let (stream, _) = tokio::io::duplex(2);
-    let fut = hyper::server::conn::http1::Builder::new().serve_connection(stream, static_);
+    let fut =
+        hyper::server::conn::http1::Builder::new().serve_connection(TokioIo::new(stream), static_);
 
     // It's enough to show that this builds, so no need to execute anything.
     drop(fut);


### PR DESCRIPTION
There are some breaking changes between 1.0.0-rc.3 and 1.0.0-rc.4: https://github.com/hyperium/hyper/releases/tag/v1.0.0-rc.4

Resolve these issues.

Added a dependency on hyper-util for `TokioIo` type.  There does not seem to be a release of hyper-util so using git dependency: https://github.com/hyperium/hyper-util

Thanks! :)