### PR TITLE
feat: add js response content-type charset

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -4,6 +4,7 @@ use mime_guess::{Mime, MimeGuess};
 use std::fs::Metadata;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::path::PathBuf;
+use std::str::FromStr;
 use tokio::fs::File;
 
 /// The result of `resolve`.
@@ -99,7 +100,7 @@ pub async fn resolve_path(
 
     // If not a directory, serve this file.
     if !is_dir_request {
-        let mime = MimeGuess::from_path(&full_path).first_or_octet_stream();
+        let mime = set_charset(MimeGuess::from_path(&full_path).first_or_octet_stream());
         return Ok(ResolveResult::Found(file, metadata, mime));
     }
 
@@ -118,4 +119,12 @@ pub async fn resolve_path(
     // Serve this file.
     let mime = MimeGuess::from_path(full_path).first_or_octet_stream();
     Ok(ResolveResult::Found(file, metadata, mime))
+}
+
+fn set_charset(mime: Mime) -> Mime {
+    let javascript_mime: Mime = "application/javascript".parse().unwrap();
+    if mime == javascript_mime {
+        return Mime::from_str("application/javascript; charset=utf-8").unwrap();
+    }
+    mime
 }

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -212,6 +212,19 @@ async fn changes_content_type_on_extension() {
 }
 
 #[tokio::test]
+async fn changes_content_type_on_extension_js() {
+    let harness = Harness::new(vec![("file1.js", "this is file1")]);
+
+    let res = harness.get("/file1.js").await.unwrap();
+    assert_eq!(
+        res.headers().get(header::CONTENT_TYPE),
+        Some(&header::HeaderValue::from_static(
+            "application/javascript; charset=utf-8"
+        ))
+    );
+}
+
+#[tokio::test]
 async fn serves_file_with_old_if_modified_since() {
     let harness = Harness::new(vec![("file1.html", "this is file1")]);
 


### PR DESCRIPTION
when js file use as a jsonp response, the lack of 'charset=utf-8' will lead to some text is garbled. something like below pic
<img width="682" alt="image" src="https://github.com/stephank/hyper-staticfile/assets/5457239/f859cf50-513f-4c7d-940c-fcd85ee88842">
origin text be like
<img width="450" alt="image" src="https://github.com/stephank/hyper-staticfile/assets/5457239/d32ed6af-efa7-45cb-9ced-f78419eb55df">
